### PR TITLE
Fix program hanging indefinitely when the progress bar count is 0

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -226,6 +226,9 @@ pub fn sync_crates_files(
         .unwrap();
     });
 
+    sender
+        .send(ProgressBarMessage::Done)
+        .expect("Channel send should not fail");
     pb_thread.join().expect("Thread join should not fail");
 
     Ok(())

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -11,6 +11,12 @@ pub enum ProgressBarMessage {
     Println(String),
 }
 
+/// Creates a progress bar thread that can receive `ProgressBarMessage`s
+///
+/// A message of `ProgressBarMessage::Done` must be sent before calling the `JoinHandle`,
+/// otherwise the thread will hang indefinitely.
+///
+/// Sending `ProgressBarMessage::Increment` more times than the `count` will not cause any issues.
 pub fn progress_bar(
     count: Option<usize>,
     prefix: String,
@@ -30,15 +36,7 @@ pub fn progress_bar(
         pb.set_prefix(&prefix);
         pb.enable_steady_tick(500);
         pb.tick();
-        let mut progress = 0;
         loop {
-            if let Some(count) = count {
-                if count > 0 && progress == count {
-                    break;
-                } else {
-                    progress += 1;
-                }
-            }
             match receiver.recv() {
                 Ok(ProgressBarMessage::Increment) => pb.inc(1),
                 Ok(ProgressBarMessage::Println(s)) => pb.println(s),


### PR DESCRIPTION
## Issue
Program was hanging indefinitely when the progress bar count is 0.
```
$ panamax sync .
Syncing Rustup repositories...
[1/5] Syncing rustup-init files... ██████████████████████████████████████████████████████████████████ 27/27 [00:00:00]
[2/5] Syncing latest stable...     ████████████████████████████████████████████████████████████████ 524/524 [00:00:00]
[3/5] Skipping syncing beta.
[4/5] Skipping syncing nightly.
[5/5] Cleaning old files...        ████████████████████████████████████████████████████████████████████ 0/0 [00:00:00]
Syncing Rustup repositories complete!
Syncing Crates repositories...
[1/3] Syncing crates.io-index...   ████████████████████████████████████████████████████████████████████ 1/1 [00:00:00]
[2/3] Syncing crates files...      ████████████████████████████████████████████████████████████████████ 0/0 [00:01:35]
^C
```
## Fix
Always send a `ProgressBarMessage::Done` before joining the pb thread
- simpler way of ensuring the pb thread always terminates
- no longer need to track the progress
- some documentation for the new invariants

```
$ cargo run sync .
Syncing Rustup repositories...
[1/5] Syncing rustup-init files... ██████████████████████████████████████████████████████████████████ 27/27 [00:00:00]
[2/5] Syncing latest stable...     ████████████████████████████████████████████████████████████████ 524/524 [00:00:00]
[3/5] Skipping syncing beta.
[4/5] Skipping syncing nightly.
[5/5] Cleaning old files...        ████████████████████████████████████████████████████████████████████ 0/0 [00:00:00]
Syncing Rustup repositories complete!
Syncing Crates repositories...
[1/3] Syncing crates.io-index...   ████████████████████████████████████████████████████████████████████ 1/1 [00:00:00]
[2/3] Syncing crates files...      ████████████████████████████████████████████████████████████████████ 0/0 [00:00:00]
[3/3] Merging crates.io-index...  
Syncing Crates repositories complete!
Sync complete.
```